### PR TITLE
fix: Fix compilation error from tests

### DIFF
--- a/mix.lock
+++ b/mix.lock
@@ -25,7 +25,7 @@
   "mongodb": {:hex, :mongodb, "1.0.0", "535a7e5d231ec12cd9ff5469e6a7abb68b411521b94b34f00c95659d242c5fe1", [:mix], [{:db_connection, "~> 2.4.0", [hex: :db_connection, repo: "hexpm", optional: false]}, {:decimal, "~> 2.0.0", [hex: :decimal, repo: "hexpm", optional: false]}], "hexpm", "0976a35cdaa0aa69cd52db6a69cb43da8b21e0df0b24c65ec1b98a9d1c17b29d"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.2.0", "b44d75e2a6542dcb6acf5d71c32c74ca88960421b6874777f79153bbbbd7dccc", [:mix], [], "hexpm", "52b2871a7515a5ac49b00f214e4165a40724cf99798d8e4a65e4fd64ebd002c1"},
   "parse_trans": {:hex, :parse_trans, "3.3.1", "16328ab840cc09919bd10dab29e431da3af9e9e7e7e6f0089dd5a2d2820011d8", [:rebar3], [], "hexpm", "07cd9577885f56362d414e8c4c4e6bdf10d43a8767abb92d24cbe8b24c54888b"},
-  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.6", "cf344f5692c82d2cd7554f5ec8fd961548d4fd09e7d22f5b62482e5aeaebd4b0", [:make, :mix, :rebar3], [], "hexpm", "bdb0d2471f453c88ff3908e7686f86f9be327d065cc1ec16fa4540197ea04680"},
+  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.7", "354c321cf377240c7b8716899e182ce4890c5938111a1296add3ec74cf1715df", [:make, :mix, :rebar3], [], "hexpm", "fe4c190e8f37401d30167c8c405eda19469f34577987c76dde613e838bbc67f8"},
   "telemetry": {:hex, :telemetry, "1.2.1", "68fdfe8d8f05a8428483a97d7aab2f268aaff24b49e0f599faa091f1d4e7f61c", [:rebar3], [], "hexpm", "dad9ce9d8effc621708f99eac538ef1cbe05d6a874dd741de2e689c47feafed5"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.7.0", "bc84380c9ab48177092f43ac89e4dfa2c6d62b40b8bd132b1059ecc7232f9a78", [:rebar3], [], "hexpm", "25eee6d67df61960cf6a794239566599b09e17e668d3700247bc498638152521"},
 }

--- a/test/ecto_test/type_test.exs
+++ b/test/ecto_test/type_test.exs
@@ -383,7 +383,7 @@ defmodule Ecto.Integration.TypeTest do
   @tag :json_extract_path
   test "json_extract_path with primitive values" do
     order = %Order{
-      meta: %{
+      metadata: %{
         :id => 123,
         :time => ~T[09:00:00],
         "'single quoted'" => "bar",
@@ -393,30 +393,30 @@ defmodule Ecto.Integration.TypeTest do
 
     TestRepo.insert!(order)
 
-    assert TestRepo.one(from o in Order, select: o.meta["id"]) == 123
-    assert TestRepo.one(from o in Order, select: o.meta["bad"]) == nil
-    assert TestRepo.one(from o in Order, select: o.meta["bad"]["bad"]) == nil
+    assert TestRepo.one(from o in Order, select: o.metadata["id"]) == 123
+    assert TestRepo.one(from o in Order, select: o.metadata["bad"]) == nil
+    assert TestRepo.one(from o in Order, select: o.metadata["bad"]["bad"]) == nil
 
     field = "id"
-    assert TestRepo.one(from o in Order, select: o.meta[^field]) == 123
-    assert TestRepo.one(from o in Order, select: o.meta["time"]) == "09:00:00"
-    assert TestRepo.one(from o in Order, select: o.meta["'single quoted'"]) == "bar"
-    assert TestRepo.one(from o in Order, select: o.meta["';"]) == nil
-    assert TestRepo.one(from o in Order, select: o.meta["\"double quoted\""]) == "baz"
+    assert TestRepo.one(from o in Order, select: o.metadata[^field]) == 123
+    assert TestRepo.one(from o in Order, select: o.metadata["time"]) == "09:00:00"
+    assert TestRepo.one(from o in Order, select: o.metadata["'single quoted'"]) == "bar"
+    assert TestRepo.one(from o in Order, select: o.metadata["';"]) == nil
+    assert TestRepo.one(from o in Order, select: o.metadata["\"double quoted\""]) == "baz"
   end
 
   # TODO
   @tag :map_type
   @tag :json_extract_path
   test "json_extract_path with arrays and objects" do
-    order = %Order{meta: %{tags: [%{name: "red"}, %{name: "green"}]}}
+    order = %Order{metadata: %{tags: [%{name: "red"}, %{name: "green"}]}}
     TestRepo.insert!(order)
 
-    assert TestRepo.one(from o in Order, select: o.meta["tags"][0]["name"]) == "red"
-    assert TestRepo.one(from o in Order, select: o.meta["tags"][99]["name"]) == nil
+    assert TestRepo.one(from o in Order, select: o.metadata["tags"][0]["name"]) == "red"
+    assert TestRepo.one(from o in Order, select: o.metadata["tags"][99]["name"]) == nil
 
     index = 1
-    assert TestRepo.one(from o in Order, select: o.meta["tags"][^index]["name"]) == "green"
+    assert TestRepo.one(from o in Order, select: o.metadata["tags"][^index]["name"]) == "green"
   end
 
   # TODO


### PR DESCRIPTION
`Ecto.Integration.Order` doesn't have `:meta` key in his struct, instead it has `:metadata`. Also changing the version of `ssl_verify_fun` to `1.1.7`