### PR TITLE
Release 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 2.0.0
 
-* Change underlying driver from [`mongodb`](https://github.com/elixir-mongo/mongodb) to [`mongodb_driver`](https://github.com/zookzook/elixir-mongodb-driver)
-* Remove module config options `pool`, `pool_overflow`, and `pool_timeout`
+* Change underlying driver from [`mongodb`](https://github.com/elixir-mongo/mongodb) to [`mongodb_driver`](https://github.com/zookzook/elixir-mongodb-driver) 1.4.0
+* Remove config options `pool`, `pool_overflow`, and `pool_timeout`
 * Add support for MongoDB 6.0 and 7.0
 * Add support for loading & dumping nil binaries and dumping nil dates
 
 ### Possible breaking changes
 
-Calls to `Mongo.Ecto` itself should not require any changes. However, if you make direct calls to the `Mongo` driver, you will need to update some of them to account for the `mongodb` -> `mongodb_driver` upgrade.
+Calls to the Ecto adapter itself should not require any changes. However, if you make direct calls to the `Mongo` driver, you will need to update some of them to account for the `mongodb` -> `mongodb_driver` upgrade. See [Migrating to 2.0.0](./README.md#migrating-to-200) in the Readme.
 
 ## 1.1.2
 * Add support for loading nil dates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.0.0
+
+* Change underlying driver from [`mongodb`](https://github.com/elixir-mongo/mongodb) to [`mongodb_driver`](https://github.com/zookzook/elixir-mongodb-driver)
+* Remove module config options `pool`, `pool_overflow`, and `pool_timeout`
+* Add support for MongoDB 6.0 and 7.0
+* Add support for loading & dumping nil binaries and dumping nil dates
+
+### Possible breaking changes
+
+Calls to `Mongo.Ecto` itself should not require any changes. However, if you make direct calls to the `Mongo` driver, you will need to update some of them to account for the `mongodb` -> `mongodb_driver` upgrade.
+
 ## 1.1.2
 * Add support for loading nil dates
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Possible breaking changes
 
-Calls to the Ecto adapter itself should not require any changes. However, if you make direct calls to the `Mongo` driver, you will need to update some of them to account for the `mongodb` -> `mongodb_driver` upgrade. See [Migrating to 2.0.0](./README.md#migrating-to-200) in the Readme.
+Calls to the Ecto adapter itself should not require any changes. However, if you make direct calls to the `Mongo` driver, you will need to update some of them to account for the `mongodb` -> `mongodb_driver` upgrade. See [Migrating to 2.0](./README.md#migrating-to-20) in the Readme.
 
 ## 1.1.2
 * Add support for loading nil dates

--- a/README.md
+++ b/README.md
@@ -122,11 +122,11 @@ Additionally special values are translated as follows:
 
 The adapter and the driver are tested against most recent versions from 5.0, 6.0, and 7.0.
 
-## Migrating to 2.0.0
+## Migrating to 2.0
 
-Release 2.0.0 changes the underlying driver from [`mongodb`](https://github.com/elixir-mongo/mongodb) to [`mongodb_driver`](https://github.com/zookzook/elixir-mongodb-driver) 1.4.0. Calls to the Ecto adapter itself should not require any changes. Some config options are no longer used and can be simply deleted: `pool`, `pool_overflow`, `pool_timeout`.
+Release 2.0 changes the underlying driver from [`mongodb`](https://github.com/elixir-mongo/mongodb) to [`mongodb_driver`](https://github.com/zookzook/elixir-mongodb-driver) 1.4.0. Calls to the Ecto adapter itself should not require any changes. Some config options are no longer used and can be simply deleted: `pool`, `pool_overflow`, `pool_timeout`.
 
-If you make direct calls to the `Mongo` driver, you will need to update some of them to account for the `mongodb` -> `mongodb_driver` upgrade. These include:
+If you make direct calls to the `Mongo` driver, you will need to update some of them to account for the `mongodb` -> `mongodb_driver` upgrade. Also, remember to replace `:mongodb` with `{:mongodb_driver, "~> 1.4.0"}` in your `mix.exs`. The known updates are:
 1. `Mongo` functions no longer accept a `pool` option or `MyApp.Repo.Pool` module argument. Instead, a pool PID is expected:
     ```elixir
     # Old driver call
@@ -146,8 +146,8 @@ If you make direct calls to the `Mongo` driver, you will need to update some of 
     end
     ```
 2. [`Mongo.command`](https://hexdocs.pm/mongodb_driver/1.4.1/Mongo.html#command/3) requires a keyword list instead of a document. E.g., instead of `Mongo.command(MyApp.Repo.pool(), %{listCollections: 1}, opts)`, do `Mongo.command(MyApp.Repo.pool(), [listCollections: 1], opts)`.
-3. `Mongo.ReadPreferences.defaults` -> `Mongo.ReadPreference.merge_defaults`
-4. When passing a `hint` to `Mongo.find_one` (etc.), if the index does not exist, an error is now returned.
+3. `Mongo.ReadPreferences.defaults` is renamed to `Mongo.ReadPreference.merge_defaults`.
+4. When passing a `hint` to `Mongo.find_one` etc., if the hinted index does not exist, an error is now returned.
 
 ## Contributing
 

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Mongo.Ecto.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/elixir-mongo/mongodb_ecto"
-  @version "1.1.2"
+  @version "2.0.0"
 
   def project do
     [


### PR DESCRIPTION
Although the `Mongo.Ecto` API has no breaking changes, the underlying MongoDB driver changes (https://github.com/elixir-mongo/mongodb_ecto/pull/190), which I believe justifies a major version bump. I've added a migration guide to the Readme.