### PR TITLE
Mixfile: extra_applications instead of applications

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,7 @@ defmodule Mongo.Ecto.Mixfile do
   #
   # Type `mix help compile.app` for more information.
   def application do
-    [applications: [:ecto, :mongodb_driver, :logger, :telemetry]]
+    [extra_applications: [:logger]]
   end
 
   defp deps do

--- a/mix.exs
+++ b/mix.exs
@@ -30,7 +30,7 @@ defmodule Mongo.Ecto.Mixfile do
       {:credo, "~> 1.5.6", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.1.0", only: :dev, runtime: false},
       {:ecto, "~> 3.12"},
-      {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
+      {:ex_doc, ">= 0.0.0", only: :docs, runtime: false},
       {:excoveralls, "~> 0.16", only: :test},
       {:mongodb_driver, "~> 1.4"},
       {:telemetry, ">= 0.4.0"}


### PR DESCRIPTION
When attempting to publish from my local machine with Elixir 1.17 (or 1.15), I encountered the issue described [here](https://github.com/elixir-lang/ex_doc/issues/1797), which is due to the `applications:` key in the Mixfile. I'm guessing newer versions of mix require applications not listed there.

This PR attempts to fix the issue by using `extra_applications` instead of `applications` and eliminating entries that should start automatically (because they are included in deps). The change is per the docs in `mix help compile.app`:
```
:extra_applications - a list of OTP applications your application
    depends on which are not included in :deps (usually defined in deps/0 in
    your mix.exs). For example, here you can declare a dependency on
    applications that ship with Erlang/OTP or Elixir, like :crypto or :logger.
    Optional extra applications can be declared as a tuple, such as {:ex_unit,
    :optional}. Mix guarantees all non-optional applications are started before
    your application starts.
```

With these changes, I am now able to run `mix docs` locally, which hopefully means that `mix hex.publish` will work too. However, I am not sure whether the changes will affect consumers of the package, and if so, how to test its effect on them.