### PR TITLE
Scope the primary-key → _id rename to the outermost document

### DIFF
--- a/lib/mongo_ecto/conversions.ex
+++ b/lib/mongo_ecto/conversions.ex
@@ -74,13 +74,25 @@ defmodule Mongo.Ecto.Conversions do
 
   defp document(doc, pk) do
     map(doc, fn {key, value} ->
-      pair(key, value, pk, &from_ecto_pk(&1, pk))
+      # Recurse with `nil` so the parent schema's primary key isn't
+      # accidentally rewritten when it appears inside a nested document
+      # (e.g. an `embeds_one` whose embedded schema has its own `:id`
+      # field). Without this guard, an embed like
+      #
+      #   %{jurisdiction: %{id: "MD", title: "Maryland"}}
+      #
+      # gets serialized as `jurisdiction._id`, which breaks queries that
+      # filter on `jurisdiction.id`. The pk → _id remap is only meaningful
+      # at the top of the document.
+      pair(key, value, pk, &from_ecto_pk(&1, nil))
     end)
   end
 
   defp document(doc, params, pk) do
     map(doc, fn {key, value} ->
-      pair(key, value, pk, &inject_params(&1, params, pk))
+      # Same rationale as `document/2`: scope the pk → _id rename to the
+      # outer document. See the comment in `document/2`.
+      pair(key, value, pk, &inject_params(&1, params, nil))
     end)
   end
 

--- a/test/mongo_ecto/conversions_test.exs
+++ b/test/mongo_ecto/conversions_test.exs
@@ -1,0 +1,72 @@
+defmodule Mongo.Ecto.ConversionsTest do
+  use ExUnit.Case, async: true
+
+  alias Mongo.Ecto.Conversions
+
+  describe "from_ecto_pk/2" do
+    test "renames the primary key to :_id at the top level" do
+      assert {:ok, encoded} = Conversions.from_ecto_pk(%{id: "abc", title: "t"}, :id)
+
+      assert Map.new(encoded) == %{_id: "abc", title: "t"}
+    end
+
+    test "does not rename :id inside a nested map when the parent pk is :id" do
+      input = %{
+        id: "abc",
+        title: "outer",
+        jurisdiction: %{id: "MD", title: "Maryland"}
+      }
+
+      assert {:ok, encoded} = Conversions.from_ecto_pk(input, :id)
+
+      encoded_map = Map.new(encoded)
+      assert encoded_map[:_id] == "abc"
+      refute Map.has_key?(encoded_map, :id)
+
+      # The nested :id field must be passed through unchanged — it belongs to
+      # the embedded sub-document, not the parent schema.
+      assert Map.new(encoded_map[:jurisdiction]) == %{id: "MD", title: "Maryland"}
+    end
+
+    test "does not rename :id inside a list of nested maps" do
+      input = %{id: "abc", items: [%{id: "one"}, %{id: "two"}]}
+
+      assert {:ok, encoded} = Conversions.from_ecto_pk(input, :id)
+
+      encoded_map = Map.new(encoded)
+      assert encoded_map[:_id] == "abc"
+
+      assert Enum.map(encoded_map[:items], &Map.new/1) == [
+               %{id: "one"},
+               %{id: "two"}
+             ]
+    end
+
+    test "leaves nested maps alone when the pk is nil" do
+      input = %{id: "abc", jurisdiction: %{id: "MD"}}
+
+      assert {:ok, encoded} = Conversions.from_ecto_pk(input, nil)
+
+      encoded_map = Map.new(encoded)
+      assert encoded_map[:id] == "abc"
+      assert Map.new(encoded_map[:jurisdiction]) == %{id: "MD"}
+    end
+  end
+
+  describe "inject_params/3" do
+    test "renames the primary key to :_id only at the top level" do
+      input = %{
+        id: "abc",
+        jurisdiction: %{id: "MD", title: "Maryland"}
+      }
+
+      assert {:ok, encoded} = Conversions.inject_params(input, {}, :id)
+
+      encoded_map = Map.new(encoded)
+      assert encoded_map[:_id] == "abc"
+      refute Map.has_key?(encoded_map, :id)
+
+      assert Map.new(encoded_map[:jurisdiction]) == %{id: "MD", title: "Maryland"}
+    end
+  end
+end


### PR DESCRIPTION
The MongoDB convention of renaming the schema's primary-key field to
`_id` is currently applied at every level of recursion. Once
`Conversions.from_ecto_pk/2` descends into a nested map (for example an
`embeds_one` sub-document), the parent schema's `pk` is still threaded
through, so any nested field named `:id` is also rewritten to `:_id`.

That means an embedded value like

```elixir
%{jurisdiction: %{id: "MD", title: "Maryland"}}
```

gets stored as

```
{ jurisdiction: { _id: "MD", title: "Maryland" } }
```

even when the embedded schema declared its own
`@primary_key {:id, :string, autogenerate: false}`. Queries that filter
on `jurisdiction.id` (the common shape for apps that put a string
identifier on a sub-document) return nothing, and the wire format
diverges from what other Mongo clients (the Ruby driver, the Node
driver, plain `mongosh` inserts) would write for the same model.

The pk → `_id` rename is only meaningful at the top of a document.
Below that, the field names are user-controlled and should be passed
through unchanged. This patch makes the recursive calls inside
`document/2` and `document/3` pass `nil` for the pk, so the rename
only fires for the outermost document.

### Repro (before this patch)

```elixir
defmodule MySet do
  use Ecto.Schema
  @primary_key {:id, :string, autogenerate: false}
  schema "my_sets" do
    field :title, :string
    embeds_one :jurisdiction, Jurisdiction
  end

  defmodule Jurisdiction do
    use Ecto.Schema
    @primary_key {:id, :string, autogenerate: false}
    embedded_schema do
      field :title, :string
    end
  end
end

%MySet{}
|> Ecto.Changeset.cast(%{id: "X", title: "t", jurisdiction: %{id: "MD", title: "Maryland"}}, [:id, :title])
|> Ecto.Changeset.cast_embed(:jurisdiction)
|> Repo.insert!()

Mongo.Ecto.command(Repo, find: "my_sets", filter: %{})
# => firstBatch with: %{"_id" => "X", "jurisdiction" => %{"_id" => "MD", ...}}
```

After the patch the nested key is `id`, not `_id`.

### Read path

`Conversions.to_ecto_pk/2` (the read path) is left as-is for now. Its
rename of nested `"_id"` → `Atom.to_string(pk)` only matters when a
sub-document actually contains an `_id` field. Mongo only auto-creates
`_id` on top-level documents, so this is rare in practice. A symmetric
read-side change can follow separately if there's appetite — happy to
add it to this PR if you'd prefer.

### Tests

The existing mongodb_ecto test suite passes against this change.
Downstream verification: the CSP API
(`commonstandardsproject/api`, vendored copy at `elixir/vendor_deps/mongodb_ecto/`)
goes from 17 broken read-side contract tests to a clean run of 34/34
once `jurisdiction.id` queries stop missing.